### PR TITLE
`test_client_receiving_tstp_ttin_stops_itself` is now more deterministic.

### DIFF
--- a/quicken/lib/_asyncio.py
+++ b/quicken/lib/_asyncio.py
@@ -28,9 +28,11 @@ class DeadlineTimer:
     def expires_from_now(self, seconds):
         if seconds < 0:
             raise ValueError('seconds must be positive')
+
         self.cancel()
-        wait = seconds % self.MAX_DURATION
-        self._time_remaining = max(seconds - wait, 0)
+
+        wait = min(seconds, self.MAX_DURATION)
+        self._time_remaining = seconds - wait
         self._handle = self._loop.call_later(wait, self._handle_expiration)
 
     def expires_at(self, seconds):

--- a/quicken/lib/_multiprocessing_reduction.py
+++ b/quicken/lib/_multiprocessing_reduction.py
@@ -28,7 +28,7 @@ def reduce_textio(obj: TextIO):
     that:
 
     * doesn't require authkey (but does require base path to be set which should
-      be in a secure folder
+      be in a secure folder)
     * doesn't require random unix socket (so when we import multiprocessing.connection
       we can stub out tempfile, saving 5ms).
     """

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,2 @@
+"""Local or edited Pytest plugins.
+"""

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from unittest.mock import Mock
+
+import pytest
+
+from quicken.lib._asyncio import DeadlineTimer
+
+
+@pytest.mark.asyncio
+async def test_timer_works():
+    callback = Mock()
+    timer = DeadlineTimer(callback, asyncio.get_running_loop())
+    timer.expires_from_now(1)
+
+    await asyncio.sleep(1.1)
+
+    callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_timer_works_with_zero():
+    callback = Mock()
+    timer = DeadlineTimer(callback, asyncio.get_running_loop())
+    timer.expires_from_now(0)
+
+    await asyncio.sleep(0.01)
+
+    callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_timer_cancellation():
+    callback = Mock()
+    timer = DeadlineTimer(callback, asyncio.get_running_loop())
+    timer.expires_from_now(1)
+
+    timer.cancel()
+
+    callback.assert_not_called()

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for utilities used in tests.
+"""


### PR DESCRIPTION
Fixes #51.

Also `_asyncio.DeadlineTimer` calculates leftover time correctly.